### PR TITLE
Removed double quotes from --exclude param

### DIFF
--- a/lib/inotifywait.js
+++ b/lib/inotifywait.js
@@ -41,7 +41,7 @@ var INotifyWait = function(wpath, options) {
     if(self.options.excludes.length > 0) {
       self.options.excludes.forEach(function(item){
           args.push("--exclude");
-          args.push('"' + item + '"');
+          args.push(item);
       });
     }
 

--- a/lib/inotifywait.js
+++ b/lib/inotifywait.js
@@ -102,7 +102,8 @@ var INotifyWait = function(wpath, options) {
 
           var stats = {isDir: isDir, date: event.date};
 
-          if (event.type.indexOf('CREATE') != -1) {
+          switch (event.type) {
+          case 'CREATE':
             self.currentEvents[event.file] = 'add';
             fs.lstat(event.file, function (err, lstats) {
               if (!err && !lstats.isDirectory() && (lstats.isSymbolicLink() || lstats.nlink > 1)) {
@@ -111,20 +112,36 @@ var INotifyWait = function(wpath, options) {
                 delete self.currentEvents[event.file];
               }
             });
-          } else if (event.type.indexOf('MODIFY') != -1 || // to detect modifications on files
-              event.type.indexOf('ATTRIB') != -1) { // to detect touch on hard link
+            break;
+          case 'MOVED_TO':
+            self.currentEvents[event.file] = 'move';
+            fs.lstat(event.file, function (err, lstats) {
+              if (!err && !lstats.isDirectory() && (lstats.isSymbolicLink() || lstats.nlink > 1)) {
+                // symlink and hard link does not receive any CLOSE event
+                self.emit('move', event.file, stats);
+                delete self.currentEvents[event.file];
+              }
+            });
+            break;  
+          case 'MODIFY':
+          case 'ATTRIB':
             if (self.currentEvents[event.file] != 'add') {
               self.currentEvents[event.file] = 'change';
             }
-          } else if (event.type.indexOf('DELETE') != -1) {
+            break;
+          case 'DELETE':
             self.emit('unlink', event.file, stats);
-          } else if (event.type.indexOf('CLOSE') != -1) {
+            break;
+          case 'CLOSE':
             if (self.currentEvents[event.file]) {
               self.emit(self.currentEvents[event.file], event.file, stats);
               delete self.currentEvents[event.file];
             } else {
               self.emit('unknown', event.file, event, stats);
             }
+            break;      
+          default:
+            break;
           }
         });
 

--- a/lib/inotifywait.js
+++ b/lib/inotifywait.js
@@ -102,8 +102,7 @@ var INotifyWait = function(wpath, options) {
 
           var stats = {isDir: isDir, date: event.date};
 
-          switch (event.type[0]) {
-          case 'CREATE':
+          if (event.type.indexOf('CREATE') != -1) {
             self.currentEvents[event.file] = 'add';
             fs.lstat(event.file, function (err, lstats) {
               if (!err && !lstats.isDirectory() && (lstats.isSymbolicLink() || lstats.nlink > 1)) {
@@ -113,35 +112,32 @@ var INotifyWait = function(wpath, options) {
               }
             });
             break;
-          case 'MOVED_TO':
+          } else if (event.type.indexOf('MOVED_TO') != -1) {
             self.currentEvents[event.file] = 'move';
             fs.lstat(event.file, function (err, lstats) {
-              if (!err && !lstats.isDirectory() && (lstats.isSymbolicLink() || lstats.nlink > 1)) {
+              if (!err && !lstats.isDirectory()) {
                 // symlink and hard link does not receive any CLOSE event
                 self.emit('move', event.file, stats);
                 delete self.currentEvents[event.file];
               }
             });
-            break;  
-          case 'MODIFY':
-          case 'ATTRIB':
+            break;
+          } else if (event.type.indexOf('MODIFY') != -1 || // to detect modifications on files
+              event.type.indexOf('ATTRIB') != -1) { // to detect touch on hard link  
             if (self.currentEvents[event.file] != 'add') {
               self.currentEvents[event.file] = 'change';
             }
             break;
-          case 'DELETE':
+          } else if (event.type.indexOf('DELETE') != -1) {
             self.emit('unlink', event.file, stats);
             break;
-          case 'CLOSE':
+          } else if (event.type.indexOf('CLOSE') != -1) {
             if (self.currentEvents[event.file]) {
               self.emit(self.currentEvents[event.file], event.file, stats);
               delete self.currentEvents[event.file];
             } else {
               self.emit('unknown', event.file, event, stats);
             }
-            break;      
-          default:
-            break;
           }
         });
 

--- a/lib/inotifywait.js
+++ b/lib/inotifywait.js
@@ -111,7 +111,6 @@ var INotifyWait = function(wpath, options) {
                 delete self.currentEvents[event.file];
               }
             });
-            break;
           } else if (event.type.indexOf('MOVED_TO') != -1) {
             self.currentEvents[event.file] = 'move';
             fs.lstat(event.file, function (err, lstats) {
@@ -121,16 +120,13 @@ var INotifyWait = function(wpath, options) {
                 delete self.currentEvents[event.file];
               }
             });
-            break;
           } else if (event.type.indexOf('MODIFY') != -1 || // to detect modifications on files
               event.type.indexOf('ATTRIB') != -1) { // to detect touch on hard link  
             if (self.currentEvents[event.file] != 'add') {
               self.currentEvents[event.file] = 'change';
             }
-            break;
           } else if (event.type.indexOf('DELETE') != -1) {
             self.emit('unlink', event.file, stats);
-            break;
           } else if (event.type.indexOf('CLOSE') != -1) {
             if (self.currentEvents[event.file]) {
               self.emit(self.currentEvents[event.file], event.file, stats);

--- a/lib/inotifywait.js
+++ b/lib/inotifywait.js
@@ -102,7 +102,7 @@ var INotifyWait = function(wpath, options) {
 
           var stats = {isDir: isDir, date: event.date};
 
-          switch (event.type) {
+          switch (event.type[0]) {
           case 'CREATE':
             self.currentEvents[event.file] = 'add';
             fs.lstat(event.file, function (err, lstats) {


### PR DESCRIPTION
with double quote regex not working
es: "\\.(tmp|swp)"